### PR TITLE
add Dockerfile, use default DataDog env vars, allow custom StatsD host

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+from python:3
+
+copy app.py requirements.txt ./
+
+run pip3 install -r requirements.txt
+
+expose 8000
+
+cmd gunicorn app:app --bind 0.0.0.0 --log-file=-

--- a/app.py
+++ b/app.py
@@ -6,13 +6,10 @@ from datadog import initialize, api, statsd
 
 # get keys from enfironment variables
 SEGMENT_SHARED_SECRET = os.environ['SEGMENT_SHARED_SECRET']
-DATADOG_API_KEY = os.environ['DD_API_KEY']
-DATADOG_APP_KEY = os.environ['DD_APP_KEY']
 
 # initialize datadog
 options = {
-    'api_key': DATADOG_API_KEY,
-    'app_key': DATADOG_APP_KEY
+    'statsd_host': os.getenv('DATADOG_STATSD_HOST', None)
 }
 
 initialize(**options)


### PR DESCRIPTION
thanks for building this very useful tool!

we run segment2datadog in Kubernetes with a custom StatsD host, so a couple of changes had to be made to allow this to be deployed in our cluster.

i also took out the DD_API_* env vars since setting `DATADOG_API_KEY` is picked up the datadog agent.